### PR TITLE
LP: #1175406 Avoid possible reference to /dev/dm-*

### DIFF
--- a/src/utils/ecryptfs-setup-swap
+++ b/src/utils/ecryptfs-setup-swap
@@ -161,7 +161,7 @@ for swap in $swaps; do
 		[ -e "/dev/mapper/cryptswap$i" ] || break
 	done
 	# Add crypttab entry
-	echo "cryptswap$i $swap /dev/urandom swap,cipher=aes-cbc-essiv:sha256" >> /etc/crypttab
+	echo "cryptswap$i $(findfs UUID=$uuid) /dev/urandom swap,cipher=aes-cbc-essiv:sha256" >> /etc/crypttab
 
 	# Add fstab entry
 	echo "/dev/mapper/cryptswap$i none swap sw 0 0" >> /etc/fstab


### PR DESCRIPTION
Or just UUID=$uuid instead of $(findfs UUID=$uuid)?

After installing Kubuntu 13.04 I moved some partitions and drives around, and crypttab pointed to /dev/dm-3, which got re-numbered at some point to /dev/vg/home instead of vg/swap. So eventually it clobbered that volume when it swapped something. I think this may help.
